### PR TITLE
Video capture permission fix

### DIFF
--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -84,7 +84,7 @@ public class Capture extends CordovaPlugin {
 
     private boolean cameraPermissionInManifest;     // Whether or not the CAMERA permission is declared in AndroidManifest.xml
 
-    private final PendingRequests pendingRequests = new PendingRequests();
+    private final org.apache.cordova.mediacapture.PendingRequests pendingRequests = new org.apache.cordova.mediacapture.PendingRequests();
 
     private int numPics;                            // Number of pictures before capture activity
     private Uri imageUri;
@@ -170,7 +170,7 @@ public class Capture extends CordovaPlugin {
         // If the mimeType isn't set the rest will fail
         // so let's see if we can determine it.
         if (mimeType == null || mimeType.equals("") || "null".equals(mimeType)) {
-            mimeType = FileHelper.getMimeType(fileUrl, cordova);
+            mimeType = org.apache.cordova.mediacapture.FileHelper.getMimeType(fileUrl, cordova);
         }
         LOG.d(LOG_TAG, "Mime type = " + mimeType);
 
@@ -325,6 +325,14 @@ public class Capture extends CordovaPlugin {
      * Sets up an intent to capture video.  Result handled by onActivityResult()
      */
     private void captureVideo(Request req) {
+
+        boolean saveAlbumPermission = PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)
+            && PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+        if (!saveAlbumPermission) {
+            PermissionHelper.requestPermissions(this, TAKE_PIC_SEC,
+                new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE});
+
         if(cameraPermissionInManifest && !PermissionHelper.hasPermission(this, Manifest.permission.CAMERA)) {
             PermissionHelper.requestPermission(this, req.requestCode, Manifest.permission.CAMERA);
         } else {
@@ -504,7 +512,7 @@ public class Capture extends CordovaPlugin {
                     obj.put("type", VIDEO_3GPP);
                 }
             } else {
-                obj.put("type", FileHelper.getMimeType(Uri.fromFile(fp), cordova));
+                obj.put("type", org.apache.cordova.mediacapture.FileHelper.getMimeType(Uri.fromFile(fp), cordova));
             }
 
             obj.put("lastModifiedDate", fp.lastModified());

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -84,7 +84,7 @@ public class Capture extends CordovaPlugin {
 
     private boolean cameraPermissionInManifest;     // Whether or not the CAMERA permission is declared in AndroidManifest.xml
 
-    private final org.apache.cordova.mediacapture.PendingRequests pendingRequests = new org.apache.cordova.mediacapture.PendingRequests();
+    private final PendingRequests pendingRequests = new PendingRequests();
 
     private int numPics;                            // Number of pictures before capture activity
     private Uri imageUri;
@@ -170,7 +170,7 @@ public class Capture extends CordovaPlugin {
         // If the mimeType isn't set the rest will fail
         // so let's see if we can determine it.
         if (mimeType == null || mimeType.equals("") || "null".equals(mimeType)) {
-            mimeType = org.apache.cordova.mediacapture.FileHelper.getMimeType(fileUrl, cordova);
+            mimeType = FileHelper.getMimeType(fileUrl, cordova);
         }
         LOG.d(LOG_TAG, "Mime type = " + mimeType);
 
@@ -512,7 +512,7 @@ public class Capture extends CordovaPlugin {
                     obj.put("type", VIDEO_3GPP);
                 }
             } else {
-                obj.put("type", org.apache.cordova.mediacapture.FileHelper.getMimeType(Uri.fromFile(fp), cordova));
+                obj.put("type", FileHelper.getMimeType(Uri.fromFile(fp), cordova));
             }
 
             obj.put("lastModifiedDate", fp.lastModified());


### PR DESCRIPTION
Added a permission call to READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE for video capture - Ensures that Android will ask the user for permission the first time video capture is requested 

Built on top of a partial implementation of the fix (for image capture)